### PR TITLE
Ease the load for regex

### DIFF
--- a/findGitHubEmail
+++ b/findGitHubEmail
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-curl -s https://api.github.com/users/$1/events/public | grep email | sed -e 's/\"email\"://g' | sed -e 's/\"//g' | sed -e 's/,//g' | sed -e 's/ //g' | sort | uniq -c | sort -n | tail -n1 | awk '{ print $2 }'
+curl -s https://api.github.com/users/$1/events/public | grep email | head -n 1 | sed -e 's/\"email\"://g' | sed -e 's/\"//g' | sed -e 's/,//g' | sed -e 's/ //g' | sort | uniq -c | sort -n | awk '{ print $2 }'


### PR DESCRIPTION
Instead of doing a tail in the end of the pipes, do a head in the beginning. This will cut away all the fat for sed to cut through.
