### PR TITLE
less commands to retrieve address.

### DIFF
--- a/findGitHubEmail
+++ b/findGitHubEmail
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-curl -s https://api.github.com/users/$1/events/public | grep "email\"\(.*\)[[:alnum:]._+-]\+@" | uniq -c | awk '{print $(NF)}' | sed -e 's/[,|"]//g' | sort -n | tail -n1
+curl -s https://api.github.com/users/$1/events/public | grep "email\"\(.*\)[[:alnum:]._+-]\+@" | uniq -c | sed -e 's/[,|"]//g' | sort -n | awk '{print $(NF)}' | tail -n1


### PR DESCRIPTION
Basically, I discarded most of sed replacements and uniq'd first, then tell awk to print last column, then remove the quotes and commas and ',' and finally print the last (the most used) address.
