### PR TITLE
Return error code 1 if no email has been found

### DIFF
--- a/findGitHubEmail
+++ b/findGitHubEmail
@@ -71,4 +71,8 @@ fi
 
 if [ -n "$EMAIL" ] ; then
   echo "$EMAIL"
+  exit
 fi
+
+exit 1
+


### PR DESCRIPTION
This really small change makes your script return with error code 1 if no email could be found. This allows this command to easily be used along with other scripts:

``` bash
$ bash findGitHubEmail clue || echo Nothing found
christian@…
$ bash findGitHubEmail osudhgdsfgheuiorh || echo Nothing found
Nothing found
```
